### PR TITLE
Exclude three.js from build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "three.interactive",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "three.interactive",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "license": "MIT",
-      "dependencies": {
-        "three": "^0.138.0"
-      },
       "devDependencies": {
         "@types/three": "^0.137.0",
         "@typescript-eslint/eslint-plugin": "^5.12.1",
@@ -20,6 +17,9 @@
         "eslint-config-prettier": "^8.4.0",
         "local-web-server": "^5.1.1",
         "typescript": "^4.5.5"
+      },
+      "peerDependencies": {
+        "three": "^0.138.0"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -3492,7 +3492,8 @@
       "version": "0.138.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.138.0.tgz",
       "integrity": "sha512-xM/WwUd53ClkbHFrftW29aIzMVvyhj4rSZmIVgn6hZ/kYB7aMjDD8FFy4VJamygXSrldJuOgEJuaI+E+8mt/KA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -6258,7 +6259,8 @@
     "three": {
       "version": "0.138.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.138.0.tgz",
-      "integrity": "sha512-xM/WwUd53ClkbHFrftW29aIzMVvyhj4rSZmIVgn6hZ/kYB7aMjDD8FFy4VJamygXSrldJuOgEJuaI+E+8mt/KA=="
+      "integrity": "sha512-xM/WwUd53ClkbHFrftW29aIzMVvyhj4rSZmIVgn6hZ/kYB7aMjDD8FFy4VJamygXSrldJuOgEJuaI+E+8mt/KA==",
+      "peer": true
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "module": "./build/three.interactive.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc && esbuild src/index.ts --bundle --minify --format=esm --sourcemap --outfile=build/three.interactive.js",
+    "build": "tsc && esbuild src/index.ts --bundle --minify --format=esm --sourcemap --external:three --outfile=build/three.interactive.js",
     "lint": "eslint src/** --ext .js,.ts",
     "examples": "ws"
   },
@@ -35,7 +35,7 @@
     "url": "https://github.com/markuslerner/THREE.Interactive/issues"
   },
   "homepage": "https://github.com/markuslerner/THREE.Interactive#readme",
-  "dependencies": {
+  "peerDependencies": {
     "three": "^0.138.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I just noticed that I forgot to exclude three.js from the built output. This made it significantly larger than it should have been.
This fixes that by marking three.js as an external dependency. And it moves it to peerDependencies.

However, it introduces a new problem. The built file now starts with the following, since it's
1. a module
2. uses Raycaster and Vector2 from three.js
3. doesn't know how to import three.js
```js
import{Raycaster as a,Vector2 as h}from"three";
```

In Node.js or with any modern build tool, this works quite fine. "three" is specified in the package.json, and thus, Node/the build tool knows what to do and where to find it (`node_modules`).

However, web browsers don't. This effectively *breaks the examples*, since the examples don't go through a compile step.

There is a really nice proposal called "import maps", which solves that. It lets you specify what dependencies there are and how to get them. And Chrome already supports them. [But other browsers aren't quite that far yet.](https://caniuse.com/import-maps)